### PR TITLE
Refactored transform method for compatibility with new API

### DIFF
--- a/notebooks/transformers_for_images.ipynb
+++ b/notebooks/transformers_for_images.ipynb
@@ -760,7 +760,7 @@
     "        super().__init__()\n",
     "        self.codebook = codebook\n",
     "\n",
-    "    def _transform(self, inpt, params):\n",
+    "    def transform(self, inpt, params):\n",
     "        encoded_image_flat = codebook.predict(inpt.permute(1,2,0).reshape(-1,3).numpy())\n",
     "        return torch.LongTensor(encoded_image_flat)\n",
     "\n",
@@ -769,7 +769,7 @@
     "        super().__init__()\n",
     "        self.codebook = codebook\n",
     "\n",
-    "    def _transform(self, inpt, params):\n",
+    "    def transform(self, inpt, params):\n",
     "        decoded_image_flat = self.codebook.cluster_centers_[inpt]\n",
     "        decoded_image = decoded_image_flat.reshape((32,32,3)).astype(dtype=np.uint8)\n",
     "        return torch.LongTensor(decoded_image).permute(2,0,1)"
@@ -2529,7 +2529,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": ".venv",
+   "display_name": "Python 3 (ipykernel)",
    "language": "python",
    "name": "python3"
   },
@@ -2543,10 +2543,9 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.10.13"
-  },
-  "orig_nbformat": 4
+   "version": "3.12.3"
+  }
  },
  "nbformat": 4,
- "nbformat_minor": 2
+ "nbformat_minor": 4
 }

--- a/notebooks/transformers_for_images.ipynb
+++ b/notebooks/transformers_for_images.ipynb
@@ -2487,7 +2487,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "image = hugging_pets[\"train\"][\"image\"][0]"
+    "image = hugging_pets[\"train\"][0][\"pixel_values\"]"
    ]
   },
   {

--- a/notebooks/transformers_for_images.ipynb
+++ b/notebooks/transformers_for_images.ipynb
@@ -1504,7 +1504,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 59,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1526,7 +1526,7 @@
     "        self.n_patches = n_patches\n",
     "        self.patch_size = patch_size\n",
     "    \n",
-    "    def _transform(self, image: Any, params: Dict[str, Any]) -> Any:\n",
+    "    def transform(self, image: Any, params: Dict[str, Any]) -> Any:\n",
     "        chunks = [torch.chunk(chunk,self.n_patches, dim=2) for chunk in torch.chunk(image, self.n_patches, dim=1)]\n",
     "        flattened_chunks = torch.stack([chunk for chunk_row in chunks for chunk in chunk_row])\n",
     "        return flattened_chunks\n",

--- a/notebooks/transformers_for_images.ipynb
+++ b/notebooks/transformers_for_images.ipynb
@@ -1504,7 +1504,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 59,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -2224,11 +2224,11 @@
     "    else (image_processor.size[\"height\"], image_processor.size[\"width\"])\n",
     ")\n",
     "_transforms = v2.Compose([\n",
-    "    v2.ToImageTensor(),  # Convert to tensor, only needed if you had a PIL image\n",
+    "    v2.ToImage(),  # Correct name is ToImage(), not ToImageTensor()\n",
     "    v2.ToDtype(torch.uint8),  # optional, most input are already uint8 at this point\n",
     "    v2.AutoAugment(),\n",
     "    v2.RandomResizedCrop(size),\n",
-    "    v2.ConvertDtype(),\n",
+    "    v2.ToDtype(torch.float32),  # Replace ConvertDtype() with ToDtype(torch.float32)\n",
     "    normalize\n",
     "])\n",
     "\n",

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,3 +11,4 @@ numpy
 jupyter
 ipywidgets
 tensorboard
+accelerate>=0.26.0


### PR DESCRIPTION
Fixing the issue of API change: In the cell contains class CodeBookTransform and InverseCodeBookTransform, changed method name _transform to `transform`. Here is the correct version:

```python
from torchvision.transforms.v2 import Transform

class CodeBookTransform(Transform):
    def __init__(self, codebook):
        super().__init__()
        self.codebook = codebook

    def transform(self, inpt, params):  # Changed from _transform to transform
        encoded_image_flat = self.codebook.predict(inpt.permute(1,2,0).reshape(-1,3).numpy())
        return torch.LongTensor(encoded_image_flat)

class InverseCodeBookTransform(Transform):
    def __init__(self, codebook):
        super().__init__()
        self.codebook = codebook

    def transform(self, inpt, params):  # Changed from _transform to transform
        decoded_image_flat = self.codebook.cluster_centers_[inpt]
        decoded_image = decoded_image_flat.reshape((32,32,3)).astype(dtype=np.uint8)
        return torch.LongTensor(decoded_image).permute(2,0,1)
```